### PR TITLE
Update outdated urls

### DIFF
--- a/README.md
+++ b/README.md
@@ -2,4 +2,4 @@ akaedu.github.com
 ==============
 
 This repository contains the source for my personal site at
-<http://akaedu.github.com>.
+<https://akaedu.github.io>.

--- a/_layouts/homepage.html
+++ b/_layouts/homepage.html
@@ -4,7 +4,7 @@
 <link rel="stylesheet" type="text/css" href="/css/peter.css" />
 <title>亚嵌教育</title>
 </head>
-<a href="http://akaedu.github.com/index.html">返回首页</a> &nbsp; 
+<a href="https://akaedu.github.io/index.html">返回首页</a> &nbsp; 
 <a href="./readme">进站必读</a>
 <h1 style="text-align:center">{{ page.title }}</h1>
 <br>

--- a/_layouts/post.html
+++ b/_layouts/post.html
@@ -4,8 +4,8 @@
 <link rel="stylesheet" type="text/css" href="/css/peter.css" />
 <title>亚嵌教育</title>
 </head>
-<a href="http://akaedu.github.com/index.html">返回首页</a> &nbsp; 
-<a href="http://akaedu.github.com/readme">进站必读</a>
+<a href="https://akaedu.github.io/index.html">返回首页</a> &nbsp; 
+<a href="https://akaedu.github.io/readme">进站必读</a>
 <h1 style="text-align:center">{{ page.title }}</h1>
 <br>
 {{ content }}

--- a/index.md
+++ b/index.md
@@ -36,7 +36,7 @@ category: tech
 ##编码练习
 <ul>
 <li> <a href="/code/primary_coding.html">范例代码基础</a> </li> 
-<li> <a href="http://akaedu.github.io/practice">课后练习题目</a> </li> 
+<li> <a href="https://akaedu.github.io/practice">课后练习题目</a> </li> 
 <li> 
   <img border="0" src="http://www.akaedu.org/img/new2.gif" width="25" height="15">
   <a href="http://akaedu.codepad.org">在线编程环境</a> 

--- a/index.md
+++ b/index.md
@@ -3,7 +3,7 @@ layout: post
 title: 亚嵌教育
 category: tech 
 ---
-最近更新： 2012-8-17  
+最近更新： 2022-1-14  
 
 ##理论学习
 <ul>
@@ -13,12 +13,12 @@ category: tech
 </li>
 <li> 
   <img border="0" src="http://www.akaedu.org/img/new2.gif" width="25" height="15">
-  <a href="http://happypeter.github.com/LGCB/book/index.html" target="_blank">Linux Guide for Chinese Beginners</a> &nbsp; &nbsp; 
-  <a href="http://happypeter.github.com/LGCB/book/zh/" target="_blank">[中文版]</a> （Peter Wang老师贡献） 
+  <a href="https://happypeter.github.io/LGCB/book/index.html" target="_blank">Linux Guide for Chinese Beginners</a> &nbsp; &nbsp; 
+  <a href="https://happypeter.github.io/LGCB/book/zh/" target="_blank">[中文版]</a> （Peter Wang老师贡献） 
 </li>
 <li> 
   <img border="0" src="http://www.akaedu.org/img/new2.gif" width="25" height="15">
-  <a href="http://limingth.github.com/">源码开放学ARM</a>  (开源电子书，工具，资料，源码下载)
+  <a href="https://limingth.github.io/">源码开放学ARM</a>  (开源电子书，工具，资料，源码下载)
 </li>
 </ul>
 
@@ -36,7 +36,7 @@ category: tech
 ##编码练习
 <ul>
 <li> <a href="/code/primary_coding.html">范例代码基础</a> </li> 
-<li> <a href="http://akaedu.github.com/practice">课后练习题目</a> </li> 
+<li> <a href="http://akaedu.github.io/practice">课后练习题目</a> </li> 
 <li> 
   <img border="0" src="http://www.akaedu.org/img/new2.gif" width="25" height="15">
   <a href="http://akaedu.codepad.org">在线编程环境</a> 


### PR DESCRIPTION
Github moved Github page urls from example.github.com to example.github.io.